### PR TITLE
Move to Java 8, fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
+jdk:
+  - oraclejdk8
 script:
   - mvn test -B

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </dependency>
   </dependencies>
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 </project>


### PR DESCRIPTION
Java 7 doesn't even have a `join` method for strings, so upgrade to 8 and note it in travis because it defaults to 7.